### PR TITLE
Set bonding options via sysfs

### DIFF
--- a/etc/initramfs-tools/scripts/local-top/bond
+++ b/etc/initramfs-tools/scripts/local-top/bond
@@ -21,7 +21,7 @@ if [ -z "$BOND" ]; then
     exit 0
 fi
 
-modprobe bonding $BOND_MODE
+modprobe bonding mode=802.3ad
 
 for BOND_IFACE in ${BOND:-*}; do
     BOND_DEVICE=$(echo $BOND_IFACE | cut -d":" -f1)
@@ -29,12 +29,18 @@ for BOND_IFACE in ${BOND:-*}; do
     BOND_ADDR=$(echo $BOND_IFACE | cut -d":" -f3 | tr - :)
     log_begin_msg "Bringing up $BOND_DEVICE"
     ip link add $BOND_DEVICE type bond
+    for option in $BOND_MODE; do
+            file=$(echo $option | cut -d"=" -f1)
+            value=$(echo $option | cut -d"=" -f2)
+            echo $value > /sys/class/net/$BOND_DEVICE/bonding/$file
+    done
     for BOND_SLAVE in $BOND_SLAVES; do
         ip link set $BOND_SLAVE master $BOND_DEVICE
     done
     if [ -n "$BOND_ADDR" ]; then
         ip link set $BOND_DEVICE address $BOND_ADDR
     fi
+    ip link set $BOND_DEVICE up
     log_end_msg
 done
 


### PR DESCRIPTION
For an unkonwn reason setting the bond options with modprobe or via the
kernel command line doesn't work on my system. It always defaults to the
balance-rr algorithm. This changes the script so the settings are
configured using sysfs which works fine on my Ubuntu 22.04 system.